### PR TITLE
JSON data source plugin - Minor changes

### DIFF
--- a/json_loader/pyproject.toml
+++ b/json_loader/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "json_loader"
-version = "0.0.1"
+version = "1.0.1"
 description = "Json loader"
 dependencies = [
     "graph-visualizer-api==0.1.0",

--- a/json_loader/visualizer/plugin/json_loader.py
+++ b/json_loader/visualizer/plugin/json_loader.py
@@ -44,7 +44,7 @@ class JsonLoader(DataSourcePlugin):
         return "json_loader"
 
     def name(self) -> str:
-        return "JsonLoader"
+        return "Json Loader"
 
     def load(self, file_string: Optional[str], **kwargs) -> Graph:
         if not file_string:
@@ -108,13 +108,9 @@ class JsonLoader(DataSourcePlugin):
                     self.__parse_reference(graph, parent_node, relation_name, parsed_json)
                     return
 
-                if not self.__get_node_by_id(str(parsed_json)):
-                    node: Node = Node(parsed_json)
-                    self.__insert_node(str(parsed_json), node)
-                    graph.insert_node(node)
-                    if parent_node and relation_name:
-                        edge: Edge = Edge(parent_node, node, **{relation_name: True})
-                        graph.insert_edge(edge)
+                literal_node: Node = Node(None, type="literal", value=parsed_json)
+                graph.insert_node(literal_node)
+                graph.insert_edge(Edge(parent_node, literal_node, **{relation_name: True}))
 
     def __parse_dict_pair(self, graph: Graph, node: Node, key: str, value: Any) -> None:
         if key == self.id:


### PR DESCRIPTION
Updated the parsing of list literals: each literal now creates a node, and an edge is added between the key and the literal. This makes it easier to attach metadata to the literal by adding it to the edge.
Example:
```json
[
  {
    "@id": "reference"
  },
  {
    "@id": "node",
    "key": ["&reference", "not_reference", 1234, 69.234]
  }
]
```
<img width="778" height="778" alt="image" src="https://github.com/user-attachments/assets/897072fa-678e-4ae2-900f-5a51391d1772" />
